### PR TITLE
Deprecate python 2x support

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.8]
+        python-version: [3.8]
     env:
       workdir: python
     steps:


### PR DESCRIPTION
Python 2.x has already been deprecated as of January 2020, since the python tests are failing, deprecating for `pins` as well.