### PR TITLE
Finish enabling pin() test for local python board

### DIFF
--- a/python/src/pins/__init__.py
+++ b/python/src/pins/__init__.py
@@ -9,6 +9,14 @@ import pins.host
 
 _logger = logging.getLogger(__name__)
 
+def _resolve(promise):
+  global _resolved
+  def resolve(value):
+    global _resolved
+    _resolved = value.value
+  promise["then"](resolve)
+  return _resolved
+
 def host_log(message):
   _logger.info(message)
 
@@ -46,15 +54,7 @@ def board_list():
 
 def board_register(board, name = None, cache = None, versions = None):
   global _pins_lib
-  promise = _pins_lib["boardRegister"](board, { "name": name, "cache": cache, "versions": versions })
-
-  global _resolved
-  def resolve(value):
-    global _resolved
-    _resolved = value.value
-  promise["then"](resolve)
-
-  return _resolved
+  return _resolve(_pins_lib["boardRegister"](board, { "name": name, "cache": cache, "versions": versions }))
 
 def callbacks_set(name, callback):
   global _pins_lib
@@ -63,6 +63,6 @@ def callbacks_set(name, callback):
 
 def pin(x, name, board):
   global _pins_lib
-  return _pins_lib["pin"](x, {"name": name, "board": board})
+  return _resolve(_pins_lib["pin"](x, {"name": name, "board": board}))
 
 pins_configure()

--- a/python/tests/board_test.py
+++ b/python/tests/board_test.py
@@ -41,7 +41,7 @@ def test_can_pin_file(board):
 
     cached_path = pins.pin(config["text_file_path"], name=pin_name, board=board)
 
-    # assert len(cached_path) > 0
+    assert len(cached_path) > 0
 
     # in_file = open(config["text_file_path"], "r")
     # lines = in_file.readlines()

--- a/python/tests/board_test.py
+++ b/python/tests/board_test.py
@@ -43,8 +43,8 @@ def test_can_pin_file(board):
 
     assert len(cached_path) > 0
 
-    # in_file = open(config["text_file_path"], "r")
-    # lines = in_file.readlines()
-    # in_file.close()
+    in_file = open(config["text_file_path"], "r")
+    lines = in_file.readlines()
+    in_file.close()
 
-    # assert lines == ['hello world'];
+    assert lines == ['hello world'];


### PR DESCRIPTION
We were not that far from enabling python tests for `pin()`, I think the next step is to port a `pin()` tests for S3 boards in python.