### PR TITLE
Avoid symlinks in windows by porting rstudio/pull/313

### DIFF
--- a/js/hosts/pins.browser.js
+++ b/js/hosts/pins.browser.js
@@ -157,3 +157,5 @@ pins.callbacks.set("getFunction", () => {});
 
 pins.callbacks.set("readRDS", () => "");
 pins.callbacks.set("saveRDS", () => "");
+
+pins.callbacks.set("supportsLinks", () => false);

--- a/js/hosts/pins.node.js
+++ b/js/hosts/pins.node.js
@@ -257,6 +257,8 @@ var init = function(pins) {
   pins.callbacks.set("readRDS", () => "");
   pins.callbacks.set("saveRDS", () => "");
 
+  pins.callbacks.set("supportsLinks", () => false);
+
   return pins;
 };
 

--- a/js/src/host/file-system.js
+++ b/js/src/host/file-system.js
@@ -14,6 +14,10 @@ export function writeLines(filePath, content) {
   return callbacks.get('writeLines')(filePath, content);
 }
 
+export function supportsLinks() {
+  return callbacks.get('supportsLinks')();
+}
+
 export const dir = Object.freeze({
   create(dirPath, options = { recursive: false }) {
     return callbacks.get('dirCreate')(dirPath, options);

--- a/js/src/pin-extensions.js
+++ b/js/src/pin-extensions.js
@@ -134,7 +134,10 @@ export async function boardPinStore(board, opts) {
               if (
                 fileSystem.fileExists(from) &&
                 fileSystem.fileSize(from) >=
-                  options.getOption('pins.link.size', Math.pow(10, 8))
+                  options.getOption(
+                    'pins.link.size',
+                    Math.pow(10, 8) && fileSystem.supportsLinks()
+                  )
               )
                 fileSystem.createLink(
                   from,

--- a/js/src/pin-extensions.js
+++ b/js/src/pin-extensions.js
@@ -134,10 +134,8 @@ export async function boardPinStore(board, opts) {
               if (
                 fileSystem.fileExists(from) &&
                 fileSystem.fileSize(from) >=
-                  options.getOption(
-                    'pins.link.size',
-                    Math.pow(10, 8) && fileSystem.supportsLinks()
-                  )
+                  options.getOption('pins.link.size', Math.pow(10, 8)) &&
+                fileSystem.supportsLinks()
               )
                 fileSystem.createLink(
                   from,

--- a/python/src/pins/host.py
+++ b/python/src/pins/host.py
@@ -128,6 +128,9 @@ def _callback_create_link(source, to):
 def _callback_file_size(path):
   return pathlib.Path(path.value).stat().st_size
 
+def _callback_supports_links():
+  return False
+
 def init_callbacks():
   pins.callbacks_set("dirCreate", _callback_dir_create)
   pins.callbacks_set("dirExists", _callback_dir_exists)
@@ -161,3 +164,5 @@ def init_callbacks():
   pins.callbacks_set("createLink", _callback_create_link)
 
   pins.callbacks_set("fileSize", _callback_file_size)
+
+  pins.callbacks_set("supportsLinks", _callback_supports_links)


### PR DESCRIPTION
Ports https://github.com/rstudio/pins/pull/313